### PR TITLE
allow relative volume to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,12 @@ $ sonos volume
 ```bash
 $ sonos volume 25
 ```
+
+The volume can also be set relative to its current value by prefixing it with
+`+` or `-`. To avoid the parameter being treated as a flag when setting
+a negative value, using `--` before.
+
+```bash
+$ sonos volume +5
+$ sonos volume -- -5
+```

--- a/sonos/api/control.py
+++ b/sonos/api/control.py
@@ -93,3 +93,8 @@ def get_group_volume(group_id):
 def set_group_volume(group_id, value):
     response = client.post(_url(f'/groups/{group_id}/groupVolume'), json={'volume': value})
     return _json(response)
+
+@auto_refresh_token(client)
+def set_group_relative_volume(group_id, value):
+    response = client.post(_url(f'/groups/{group_id}/groupVolume/relative'), json={'volumeDelta': value})
+    return _json(response)

--- a/sonos/commands/volume.py
+++ b/sonos/commands/volume.py
@@ -9,7 +9,10 @@ from sonos.config import active_group_store
 def volume(value):
     group_id = active_group_store.get_active_group()
     if value:
-        set_group_volume(group_id, value)
+        if value[0] in ('+', '-'):
+            set_group_relative_volume(group_id, value)
+        else:
+            set_group_volume(group_id, value)
     else:
         result = get_group_volume(group_id)
         click.echo(result['volume'])


### PR DESCRIPTION
This is a small change that makes the volume command adjust the relative volume when the value is prefixed with + or -.